### PR TITLE
Add the TR7 Scheme interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ mount_dir
 bochsout.txt
 bx_enh_dbg.ini
 .jinx-cache
+*~

--- a/recipes/tr7
+++ b/recipes/tr7
@@ -1,0 +1,23 @@
+name=tr7
+from_source=tr7
+revision=1
+imagedeps="gcc"
+hostdeps="gcc automake"
+deps=""
+
+build() {
+    cp -rp "${source_dir}"/. ./
+
+    make -j${parallelism}
+
+    make test
+}
+
+package() {
+    DESTDIR="${dest_dir}"
+    install -v -D -t $DESTDIR/usr/local/bin tr7i
+    # install -v -D -t $DESTDIR/usr/local/lib libtr7.so*
+    # install -v -D -t $DESTDIR/usr/local/include tr7libs
+    mkdir -p $DESTDIR/usr/local/include
+    cp -r tr7libs $DESTDIR/usr/local/include
+}

--- a/recipes/tr7
+++ b/recipes/tr7
@@ -1,22 +1,23 @@
 name=tr7
 from_source=tr7
 revision=1
-imagedeps="gcc"
+imagedeps=""
 hostdeps="gcc automake"
 deps="core-libs"
 
 build() {
     cp -rp "${source_dir}"/. ./
 
+    # FIXME: printing of floats is broken, it always outputs %f.0
     # Disable <wchar> as mlibc does not support it
-    CC="x86_64-ironclad-gcc" HOSTCC="gcc" make -j${parallelism} FFLAGS="-DNO_WCHAR"
+    # Make only tr7i as the .a library fails due to "ar"
+    CC="x86_64-ironclad-gcc" make -j${parallelism} tr7i FFLAGS="-DNO_WCHAR"
 }
 
 package() {
-    DESTDIR="${dest_dir}"
-    install -v -D -t $DESTDIR/usr/local/bin tr7i
-    # install -v -D -t $DESTDIR/usr/local/lib libtr7.so*
-    # install -v -D -t $DESTDIR/usr/local/include tr7libs
-    mkdir -p $DESTDIR/usr/local/include
-    cp -r tr7libs $DESTDIR/usr/local/include
+    install -v -D -t ${prefix}/bin tr7i
+    # FIXME: maybe also compile and install share library?
+    # install -v -D -t ${prefix}/lib libtr7.so*
+    mkdir -p ${prefix}/include
+    cp -r tr7libs ${prefix}/include
 }

--- a/recipes/tr7
+++ b/recipes/tr7
@@ -15,9 +15,9 @@ build() {
 }
 
 package() {
-    install -v -D -t ${prefix}/bin tr7i
+    install -v -D -t "${dest_dir}${prefix}"/bin tr7i
     # FIXME: maybe also compile and install share library?
-    # install -v -D -t ${prefix}/lib libtr7.so*
-    mkdir -p ${prefix}/include
-    cp -r tr7libs ${prefix}/include
+    # install -v -D -t "${dest_dir}${prefix}"/lib libtr7.so*
+    mkdir -p "${dest_dir}${prefix}"/include
+    cp -r tr7libs "${dest_dir}${prefix}"/include
 }

--- a/recipes/tr7
+++ b/recipes/tr7
@@ -3,14 +3,13 @@ from_source=tr7
 revision=1
 imagedeps="gcc"
 hostdeps="gcc automake"
-deps=""
+deps="core-libs"
 
 build() {
     cp -rp "${source_dir}"/. ./
 
-    make -j${parallelism}
-
-    make test
+    # Disable <wchar> as mlibc does not support it
+    CC="x86_64-ironclad-gcc" HOSTCC="gcc" make -j${parallelism} FFLAGS="-DNO_WCHAR"
 }
 
 package() {

--- a/source-recipes/tr7
+++ b/source-recipes/tr7
@@ -1,0 +1,8 @@
+name=tr7
+version=1.0.8
+tarball_url="https://gitlab.com/jobol/tr7/-/archive/v${version}/tr7-v${version}.tar.gz"
+tarball_blake2b="57ecca405f7a6a0807b52a07a6c3bd55a5fbea2afdabae801323b96ef14fe8d118af9fe66ed69f5af0bb126f8edb5e0793dce7da13f8720fa03831cd7291f8d2"
+
+regenerate() {
+    true
+}


### PR DESCRIPTION
I am opening this PR in order to get an initial review going. I am sure that my way of doing things is far from acceptable. The TR7 interpreter, `tr7i` also does not currently run, it generated an `EACCESS` error even when running as root...